### PR TITLE
support cache_dir for weights download

### DIFF
--- a/src/controlnet_aux/hed/__init__.py
+++ b/src/controlnet_aux/hed/__init__.py
@@ -99,9 +99,9 @@ class HEDdetector:
         self.netNetwork = netNetwork.eval()
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_or_path, filename=None):
+    def from_pretrained(cls, pretrained_model_or_path, filename=None, cache_dir=None):
         filename = filename or "annotator/ckpts/network-bsds500.pth"
-        model_path = hf_hub_download(pretrained_model_or_path, filename)
+        model_path = hf_hub_download(pretrained_model_or_path, filename, cache_dir=cache_dir)
 
         netNetwork = Network(model_path)
 

--- a/src/controlnet_aux/midas/__init__.py
+++ b/src/controlnet_aux/midas/__init__.py
@@ -14,9 +14,9 @@ class MidasDetector:
 
         
     @classmethod
-    def from_pretrained(cls, pretrained_model_or_path, model_type="dpt_hybrid", filename=None):
+    def from_pretrained(cls, pretrained_model_or_path, model_type="dpt_hybrid", filename=None, cache_dir=None):
         filename = filename or "annotator/ckpts/dpt_hybrid-midas-501f0c75.pt"
-        model_path = hf_hub_download(pretrained_model_or_path, filename)
+        model_path = hf_hub_download(pretrained_model_or_path, filename, cache_dir=cache_dir)
         return cls(model_type=model_type, model_path=model_path)
         
     def __call__(self, input_image, a=np.pi * 2.0, bg_th=0.1):

--- a/src/controlnet_aux/mlsd/__init__.py
+++ b/src/controlnet_aux/mlsd/__init__.py
@@ -16,9 +16,9 @@ class MLSDdetector:
         self.model = model.eval()
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_or_path, filename=None):
+    def from_pretrained(cls, pretrained_model_or_path, filename=None, cache_dir=None):
         filename = filename or "annotator/ckpts/mlsd_large_512_fp32.pth"
-        model_path = hf_hub_download(pretrained_model_or_path, filename)
+        model_path = hf_hub_download(pretrained_model_or_path, filename, cache_dir=cache_dir)
 
         model = MobileV2_MLSD_Large()
         model.load_state_dict(torch.load(model_path), strict=True)

--- a/src/controlnet_aux/open_pose/__init__.py
+++ b/src/controlnet_aux/open_pose/__init__.py
@@ -31,9 +31,9 @@ class OpenposeDetector:
         self.body_estimation = body_estimation
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_or_path, filename=None):
+    def from_pretrained(cls, pretrained_model_or_path, filename=None, cache_dir=None):
         filename = filename or "annotator/ckpts/body_pose_model.pth"
-        body_model_path = hf_hub_download(pretrained_model_or_path, filename)
+        body_model_path = hf_hub_download(pretrained_model_or_path, filename, cache_dir=cache_dir)
 
         body_estimation = Body(body_model_path)
 


### PR DESCRIPTION
This patch exposes the cache_dir method of `hf_hub_download` similar to other `from_pretrained` diffusers models.