### PR TITLE
Bump package version to 0.0.2 to fix compatibility issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ from distutils.core import Command
 
 from setuptools import find_packages, setup
 
-
 # IMPORTANT:
 # 1. all dependencies should be listed here with their version requirements if any
 # 2. once modified, run: `make deps_table_update` to update src/diffusers/dependency_versions_table.py
@@ -87,7 +86,8 @@ _deps = [
     "matplotlib",
     "scipy",
     "huggingface_hub",
-    "einops"
+    "einops",
+    "timm",
 ]
 
 # this is a lookup table with items like:
@@ -96,7 +96,9 @@ _deps = [
 # packaging: "packaging"
 #
 # some of the values are versioned whereas others aren't.
-deps = {b: a for a, b in (re.findall(r"^(([^!=<>~]+)(?:[!=<>~].*)?$)", x)[0] for x in _deps)}
+deps = {
+    b: a for a, b in (re.findall(r"^(([^!=<>~]+)(?:[!=<>~].*)?$)", x)[0] for x in _deps)
+}
 
 # since we save this data in src/diffusers/dependency_versions_table.py it can be easily accessed from
 # anywhere. If you need to quickly access the data from this table in a shell, you can do so easily with:
@@ -128,7 +130,11 @@ class DepsTableUpdateCommand(Command):
     description = "build runtime dependency table"
     user_options = [
         # format: (long option, short option, description).
-        ("dep-table-update", None, "updates src/diffusers/dependency_versions_table.py"),
+        (
+            "dep-table-update",
+            None,
+            "updates src/diffusers/dependency_versions_table.py",
+        ),
     ]
 
     def initialize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,7 @@ install_requires = [
 
 setup(
     name="controlnet_aux",
-    version="0.0.1",  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
+    version="0.0.2",  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
     description="Human Pose",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/src/controlnet_aux/__init__.py
+++ b/src/controlnet_aux/__init__.py
@@ -1,7 +1,7 @@
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
-from .open_pose import OpenposeDetector
-from .mlsd import MLSDdetector
-from .hed import HEDdetector
 from .canny import CannyDetector
+from .hed import HEDdetector
 from .midas import MidasDetector
+from .mlsd import MLSDdetector
+from .open_pose import OpenposeDetector


### PR DESCRIPTION
Version 0.0.1 did not include Canny and MidasDetector on the first release on PyPI, so, all the people that installed this package before now need to manually reinstall the package as it shares the same version number (and in that matter breaks pip versioning system).

@patrickvonplaten can you please publish it on PyPI again with this version bump?

PS: I really love your work, thanks for all the stuff you created, I would never get into SD without Diffusers, Huggingface, and this package for controlnet.