### PR TITLE
fix Overload resolution failed

### DIFF
--- a/src/controlnet_aux/lineart_anime/__init__.py
+++ b/src/controlnet_aux/lineart_anime/__init__.py
@@ -156,7 +156,7 @@ class LineartAnimeDetector:
             image_feed = rearrange(image_feed, 'h w c -> 1 c h w')
 
             line = self.model(image_feed)[0, 0] * 127.5 + 127.5
-            line = line.cpu().numpy()
+            line = line.cpu().numpy().astype(np.uint8)
 
             line = cv2.resize(line, (W, H), interpolation=cv2.INTER_CUBIC)
             line = line.clip(0, 255).astype(np.uint8)
@@ -170,7 +170,7 @@ class LineartAnimeDetector:
 
         detected_map = cv2.resize(detected_map, (W, H), interpolation=cv2.INTER_LINEAR)
         detected_map = 255 - detected_map
-        
+
         if return_pil:
             detected_map = Image.fromarray(detected_map)
 


### PR DESCRIPTION
Fixes an issue similar to [OpenCV resize issue](https://github.com/patrickvonplaten/controlnet_aux/issues/9)

When passing a 512x640 image to `lineart_anime` we get a 
```
cv2.error: OpenCV(4.7.0) :-1: error: (-5:Bad argument) in function 'resize'
> Overload resolution failed:
>  - src data type = 23 is not supported
>  - Expected Ptr<cv::UMat> for argument 'src'
```

It's fixed by casting the image from `float` to `uint8` before passing it to `cv2.resize()`